### PR TITLE
Bugfix in copy_expert method

### DIFF
--- a/psycopg2cffi/_impl/cursor.py
+++ b/psycopg2cffi/_impl/cursor.py
@@ -468,11 +468,13 @@ class Cursor(object):
             raise TypeError("file must be a readable file-like object for"
                 " COPY FROM; a writeable file-like object for COPY TO.")
 
+        self._copysize = size
         self._copyfile = file
         try:
             self._pq_execute(sql)
         finally:
             self._copyfile = None
+            self._copysize = None
 
     @check_closed
     def setinputsizes(self, sizes):


### PR DESCRIPTION
We currently use psycopg2ct in production at our organization, and we have our own fork with this patch applied.  To be perfectly honest, I'm not sure exactly what it does, as it was written by someone who doesn't work for us anymore, but apparently it resolved some bug in our application that I'm not sure how to trigger.

I'd like to, firstly, not have to maintain our own fork, and secondly, switch to cffi since it seems to perform better, so I'm submitting this to you guys to see if it seems sane.  If it does, merge away.  I'm sorry I don't have any test cases or anything to go with it.

(For what it's worth, I also submitted a similar pull request to the main psycopg2-ctypes repo a couple of months ago, but never heard back.)
