### PR TITLE
Allow cffi 0.5, since it works fine and is current.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -284,7 +284,7 @@ setup(
     long_description=''.join(README),
     packages=['psycopg2cffi', 'psycopg2cffi._impl', 'psycopg2cffi.tests'],
     install_requires=[
-        'cffi==0.4',
+        'cffi ==0.4, ==0.5',
         ],
     ext_package='psycopg2cffi',
     ext_modules=ext_modules,


### PR DESCRIPTION
psycopg2cffi currently hard-requires cffi 0.4.  As far as I can tell, it also works fine with 0.5, and another of my project's dependencies requires 0.5, which means setting up my environment requires some manual twiddling.  This patch adds 0.5 as an option in setup.py.
