### PR TITLE
Fix TypeError in libpq.PQconnectdb with unicode

### DIFF
--- a/psycopg2cffi/_impl/connection.py
+++ b/psycopg2cffi/_impl/connection.py
@@ -132,7 +132,7 @@ class Connection(object):
             self._connect_async()
 
     def _connect_sync(self):
-        self._pgconn = libpq.PQconnectdb(self.dsn)
+        self._pgconn = libpq.PQconnectdb(self.dsn.encode('utf-8'))
         if not self._pgconn:
             raise exceptions.OperationalError('PQconnectdb() failed')
         elif libpq.PQstatus(self._pgconn) == libpq.CONNECTION_BAD:

--- a/psycopg2cffi/tests/psycopg2_tests/test_connection.py
+++ b/psycopg2cffi/tests/psycopg2_tests/test_connection.py
@@ -249,6 +249,14 @@ class ConnectionTests(ConnectingTestCase):
         cur.execute("select 1 as a")
         self.assertRaises(TypeError, (lambda r: r['a']), cur.fetchone())
 
+    def test_connect_non_unicode_dsn(self):
+        conn = psycopg2.connect(str(dsn))
+        conn.close()
+
+    def test_connect_unicode_dsn(self):
+        conn = psycopg2.connect(unicode(dsn))
+        conn.close()
+
 
 class IsolationLevelsTestCase(ConnectingTestCase):
 


### PR DESCRIPTION
Guarentees conninfo arguement for PQconnectdb c call is of type str
Prior to this, dsn could be of type unicode which raises a TypeError

``` python
­­­>>> type(self.dsn)
<type 'unicode'>
>>> libpq.PQconnectdb(self.dsn)
TypeError: initializer for ctype 'char *' must be a str or list or tuple, not unicode
```
