### PR TITLE
Fixed an error in the build's benchmarks suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ python:
 install: python setup.py install
 script: python setup.py test
 after_script:
+  - "psql -c 'create database psycopg2_cffi_test_db;' -U postgres"
   - git clone https://github.com/chtd/psycopg2-benchmarks.git --depth 1
   - pip install -r psycopg2-benchmarks/django_bench/requirements.txt
   - cd psycopg2-benchmarks/django_bench/ && ./bench 1000 5


### PR DESCRIPTION
The benchmarks were reporting that the database does not exist and somehow they ran anyway.
I added the database to get rid of the error.