### PR TITLE
Encode values to bytes in Python 3

### DIFF
--- a/psycopg2cffi/_impl/cursor.py
+++ b/psycopg2cffi/_impl/cursor.py
@@ -960,6 +960,8 @@ def _combine_cmd_params(cmd, params, conn):
             if key not in arg_values:
                 arg_values[key] = _getquoted(params[key], conn)
             parts.append(cmd[next_start:idx])
+            if isinstance(arg_values[key], six.text_type):
+                arg_values[key] = arg_values[key].encode(conn._py_enc)
             parts.append(arg_values[key])
             n_arg_values += 1
             next_start = end + 2
@@ -978,6 +980,8 @@ def _combine_cmd_params(cmd, params, conn):
             _check_format_char(cmd[idx + 1], idx)
 
             value = _getquoted(params[param_num], conn)
+            if isinstance(value, six.text_type):
+                value = value.encode(conn._py_enc)
             n_arg_values += 1
             parts.append(cmd[next_start:idx])
             parts.append(value)

--- a/psycopg2cffi/_impl/cursor.py
+++ b/psycopg2cffi/_impl/cursor.py
@@ -960,7 +960,7 @@ def _combine_cmd_params(cmd, params, conn):
             if key not in arg_values:
                 arg_values[key] = _getquoted(params[key], conn)
             parts.append(cmd[next_start:idx])
-            if isinstance(arg_values[key], six.text_type):
+            if six.PY3 and isinstance(arg_values[key], six.text_type):
                 arg_values[key] = arg_values[key].encode(conn._py_enc)
             parts.append(arg_values[key])
             n_arg_values += 1
@@ -980,7 +980,7 @@ def _combine_cmd_params(cmd, params, conn):
             _check_format_char(cmd[idx + 1], idx)
 
             value = _getquoted(params[param_num], conn)
-            if isinstance(value, six.text_type):
+            if six.PY3 and isinstance(value, six.text_type):
                 value = value.encode(conn._py_enc)
             n_arg_values += 1
             parts.append(cmd[next_start:idx])


### PR DESCRIPTION
This solves a problem in GeoDjango in python 3, where the Geo objects are coming in as objects and are converted for the DB as strings.  By forcing encoding, we ensure that they are able to be inserted.  

Without the encoding change, the final join (return b''.join(parts)) will fail with a type conversion error.

    
