### PR TITLE
Raise an exception in pq_clear_async when status is fatal.

### DIFF
--- a/psycopg2cffi/_impl/connection.py
+++ b/psycopg2cffi/_impl/connection.py
@@ -485,7 +485,7 @@ class Connection(object):
                 # Get the cursor object from the weakref
                 curs = self._async_cursor()
                 if curs is None:
-                    util.pq_clear_async(self._pgconn)
+                    util.pq_clear_async(self)
                     raise exceptions.InterfaceError(
                         "the asynchronous cursor has disappeared")
 

--- a/psycopg2cffi/_impl/cursor.py
+++ b/psycopg2cffi/_impl/cursor.py
@@ -838,7 +838,7 @@ class Cursor(object):
 
         libpq.PQputCopyEnd(pgconn, errmsg)
         self._clear_pgres()
-        util.pq_clear_async(pgconn)
+        util.pq_clear_async(self._conn)
 
     def _pq_fetch_copy_out(self):
         is_text = isinstance(self._copyfile, TextIOBase)
@@ -861,7 +861,7 @@ class Cursor(object):
                 break
 
         self._clear_pgres()
-        util.pq_clear_async(pgconn)
+        util.pq_clear_async(self._conn)
 
     def _build_row(self):
         row_num = self._rownumber

--- a/psycopg2cffi/_impl/util.py
+++ b/psycopg2cffi/_impl/util.py
@@ -15,11 +15,16 @@ def pq_set_non_blocking(pgconn, arg, raise_exception=False):
     return ret
 
 
-def pq_clear_async(pgconn):
+def pq_clear_async(conn):
+    pgconn = conn._pgconn
     while True:
         pgres = libpq.PQgetResult(pgconn)
         if not pgres:
             break
+
+        if libpq.PQresultStatus(pgres) == libpq.PGRES_FATAL_ERROR:
+            raise conn._create_exception()
+
         libpq.PQclear(pgres)
 
 


### PR DESCRIPTION
This fixes an issue when copy_from and copy_to appears to be successful
but an error actually occurred in the backend.
Test case has been added relating to invalid foreign keys.