### PR TITLE
Notice handler fails when notice contains utf8 bytes

### DIFF
--- a/psycopg2cffi/_impl/connection.py
+++ b/psycopg2cffi/_impl/connection.py
@@ -130,7 +130,7 @@ class Connection(object):
             'void(void *, const char *)',
             lambda arg, message: self_ref()._process_notice(
                 arg,
-                ffi.string(message).decode(self._py_enc or 'utf-8', 'replace')))
+                ffi.string(message).decode(self_ref()._py_enc or 'utf-8', 'replace')))
 
         if not self._async:
             self._connect_sync()

--- a/psycopg2cffi/_impl/connection.py
+++ b/psycopg2cffi/_impl/connection.py
@@ -129,7 +129,8 @@ class Connection(object):
         self._notice_callback = ffi.callback(
             'void(void *, const char *)',
             lambda arg, message: self_ref()._process_notice(
-                arg, bytes_to_ascii(ffi.string(message))))
+                arg,
+                ffi.string(message).decode(self._py_enc or 'utf-8', 'replace')))
 
         if not self._async:
             self._connect_sync()


### PR DESCRIPTION
Notice can arive from server as utf8 and it's decoding as ascii can cause and error, for example:

```
From cffi callback <function <lambda> at 0x0000000001dbab60>:
Traceback (most recent call last):
  File "psycopg2cffi/_impl/connection.py", line 132, in <lambda>
    arg, bytes_to_ascii(ffi.string(message))))
  File "psycopg2cffi/_impl/adapters.py", line 314, in bytes_to_ascii
    return b.decode('ascii')
UnicodeDecodeError: ('ascii', '...
```
Same issue as https://github.com/chtd/psycopg2cffi/issues/56