### PR TITLE
allow named cursors outside of transactions if the cursor is withheld

### DIFF
--- a/psycopg2cffi/_impl/cursor.py
+++ b/psycopg2cffi/_impl/cursor.py
@@ -233,7 +233,7 @@ class Cursor(object):
             if self._query:
                 raise ProgrammingError(
                     "can't call .execute() on named cursors more than once")
-            if self._conn.autocommit:
+            if self._conn.autocommit and not self._withhold:
                 raise ProgrammingError(
                     "can't use a named cursor outside of transactions")
 


### PR DESCRIPTION
This mirrors the equivalent check in psyco_curs_execute() in regular
psycopg2, and fixes an error I saw in Django admin views. I saw the error when using psycopg2cffi with PyPy as well as CPython.