### PR TITLE
Fix for changing status to STATUS_READY after setting datestyle #88

### DIFF
--- a/psycopg2cffi/_impl/connection.py
+++ b/psycopg2cffi/_impl/connection.py
@@ -628,6 +628,7 @@ class Connection(object):
             if not self._iso_compatible_datestyle():
                 self.status = consts.STATUS_DATESTYLE
                 self._set_guc('datestyle', 'ISO')
+                self.status = consts.STATUS_READY
 
             self._closed = 0
 


### PR DESCRIPTION
When datestyle is not equal to ISO, there is situation that decorator check_notrans failing because of status.