### PR TITLE
Adds support for two-part version numbering scheme 

### DIFF
--- a/psycopg2cffi/_impl/_build_libpq.py
+++ b/psycopg2cffi/_impl/_build_libpq.py
@@ -152,7 +152,7 @@ Please add the directory containing pg_config to the PATH.
             pgversion = '7.4.0'
 
         verre = re.compile(
-            r'(\d+)\.(\d+)(?:(?:\.(\d+))|(devel|(alpha|beta|rc)\d+))')
+            r'(\d+)\.(\d+)(?:(?:\.(\d+))|(devel|(alpha|beta|rc)\d+)?)')
         m = verre.match(pgversion)
         if m:
             pgmajor, pgminor, pgpatch = m.group(1, 2, 3)


### PR DESCRIPTION
Postgres 10.0 onward has adopted a 2-part numbering scheme. This small change enables psycopg2cffi to build correctly.