### PR TITLE
Replaced argument 'async' with 'async_' #103

### DIFF
--- a/psycopg2cffi/__init__.py
+++ b/psycopg2cffi/__init__.py
@@ -88,11 +88,11 @@ def connect(dsn=None,
     if port is not None:
         items.append(('port', port))
 
-    kwasync = {}
+    async_ = False
     if 'async' in kwargs:
-        kwasync['async'] = kwargs.pop('async')
+        async_ = kwargs.pop('async')
     if 'async_' in kwargs:
-        kwasync['async_'] = kwargs.pop('async_')
+        async_ = kwargs.pop('async_')
 
     items.extend([(k, v) for (k, v) in kwargs.items() if v is not None])
 
@@ -108,7 +108,7 @@ def connect(dsn=None,
             dsn = " ".join(["%s=%s" % (k, _param_escape(str(v)))
                 for (k, v) in items])
 
-    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
+    conn = _connect(dsn, connection_factory=connection_factory, async_=async_)
     if cursor_factory is not None:
         conn.cursor_factory = cursor_factory
 


### PR DESCRIPTION
I don't think that the `_connect` method that's getting called here needs to accept both `async=` and `async_=` keyword arguments, so there's an opportunity to avoid the creation of a dict. We can just pass a bool into the `_connect` method directly.

Note that `_connect` is already careful to not pass on an `async_` argument unless `async_`'s value is True:
```python
def _connect(dsn, connection_factory=None, async_=False):                       
    if connection_factory is None:                                              
        connection_factory = Connection                                         
                                                                                
    # Mimic the construction method as used by psycopg2, which notes:           
    # Here we are breaking the connection.__init__ interface defined            
    # by psycopg2. So, if not requiring an async conn, avoid passing            
    # the async_ parameter.                                                     
    if async_:                                                                  
        return connection_factory(dsn, async_=True)                             
    else:                                                                       
        return connection_factory(dsn)
```