### PR TITLE
Allow adapters to be passed as arguments of cursor's execute()

### DIFF
--- a/psycopg2cffi/_impl/adapters.py
+++ b/psycopg2cffi/_impl/adapters.py
@@ -289,7 +289,10 @@ def _getquoted(param, conn):
     """Helper method"""
     if param is None:
         return b'NULL'
-    adapter = adapt(param)
+    if isinstance(param, _BaseAdapter):
+        adapter = param
+    else:
+        adapter = adapt(param)
     try:
         adapter.prepare(conn)
     except AttributeError:


### PR DESCRIPTION
psycopg2 allows to pass Adapter instances as arguments of cursor's
execute(). This patch will make psycopg2cffi behave the same way.

Here's a test case that can be run against psycopg2 and psycopg2cffi

```python
import psycopg2  # assuming psycopg2cffi-compat
from psycopg2.extensions import AsIs, Boolean

conn = psycopg2.connect(database='postgres')
cr = conn.cursor()
cr.execute("SELECT %s, %s", (AsIs("version()"), Boolean(True)))
print(cr.fetchone())
```

Basically psycopg2cffi does not allow users to pass an adapter in the argument list of execute() because the values will be converted/adapted no matter what.

This commit will check if the value is already an Adapter instance before trying to adapt it.