### PR TITLE
Drop support for old Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,7 @@ after_script:
 matrix:
   fast_finish: true
   include:
-    - python: "2.6"
     - python: "2.7"
-    - python: "3.3"
-    - python: "3.4"
     - python: "3.5"
     - python: "3.6"
     - python: "pypy"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py32,py33,py34,py35,py36,py37,pypy,pypy3
+envlist=py27,py34,py35,py36,py37,pypy,pypy3
 
 [testenv]
 deps=


### PR DESCRIPTION
Psycopg2 doesn't support these versions anymore.
PyPy3 is already at 3.6 so there's no need to support 3.3 anymore.
We should drop support for them.