### PR TITLE
Fix NamedTupleCursor iter bug in Python 3.7 caused by PEP 479

### DIFF
--- a/psycopg2cffi/extras.py
+++ b/psycopg2cffi/extras.py
@@ -331,7 +331,10 @@ class NamedTupleCursor(_cursor):
 
     def __iter__(self):
         it = super(NamedTupleCursor, self).__iter__()
-        t = six.next(it)
+        try:
+            t = six.next(it)
+        except StopIteration:
+            return
 
         nt = self.Record
         if nt is None:

--- a/psycopg2cffi/tests/psycopg2_tests/test_bug_pep479_namedtuplecursor_iter.py
+++ b/psycopg2cffi/tests/psycopg2_tests/test_bug_pep479_namedtuplecursor_iter.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+#
+# test_bug_pep479_namedtuplecursor_iter.py - Test iterating over a
+# NamedTupleCursor with no results. PEP 479 in Python 3.7 introduced a
+# a breaking change that causes uncaught StopIteration exceptions in
+# generators to be treated as a RuntimeError.
+
+import psycopg2cffi as psycopg2
+import psycopg2cffi.extras
+from psycopg2cffi.tests.psycopg2_tests.testconfig import dsn
+from psycopg2cffi.tests.psycopg2_tests.testutils import unittest
+
+
+class Pep479Tests(unittest.TestCase):
+
+    def setUp(self):
+        self.conn = psycopg2.connect(dsn)
+
+    def tearDown(self):
+        self.conn.close()
+
+    def test(self):
+    		curs = self.conn.cursor(cursor_factory=psycopg2.extras.NamedTupleCursor)
+    		curs.execute("select 1 as foo where false")
+    		list(curs)

--- a/psycopg2cffi/tests/psycopg2_tests/test_bug_pep479_namedtuplecursor_iter.py
+++ b/psycopg2cffi/tests/psycopg2_tests/test_bug_pep479_namedtuplecursor_iter.py
@@ -20,6 +20,6 @@ class Pep479Tests(unittest.TestCase):
         self.conn.close()
 
     def test(self):
-    		curs = self.conn.cursor(cursor_factory=psycopg2.extras.NamedTupleCursor)
-    		curs.execute("select 1 as foo where false")
-    		list(curs)
+        curs = self.conn.cursor(cursor_factory=psycopg2.extras.NamedTupleCursor)
+        curs.execute("select 1 as foo where false")
+        list(curs)


### PR DESCRIPTION
[PEP 479](https://www.python.org/dev/peps/pep-0479/) in Python 3.7 introduced a breaking change that causes uncaught StopIteration exceptions in generators to be treated as a RuntimeError instead of silently stopping the generator. The NamedTupleCursor triggers this exception when it is iterated over and it has no results from a query. As a result in Python 3.7 iterating over a cursor with no results now raises a RuntimeError where in earlier version it worked without issue. I've provided a fix for the error, and a unittest to test for the successful handling of the scenario.

```python
self = <psycopg2cffi.extras.NamedTupleCursor object at 0x00007f93030523a0>

    def __iter__(self):
        it = super(NamedTupleCursor, self).__iter__()
>       t = six.next(it)
E       StopIteration

psycopg2cffi/extras.py:334: StopIteration

The above exception was the direct cause of the following exception:

self = <psycopg2cffi.tests.psycopg2_tests.test_bug_pep479_namedtuplecursor_iter.Pep479Tests testMethod=test>

    def test(self):
                curs = self.conn.cursor(cursor_factory=psycopg2.extras.NamedTupleCursor)
                curs.execute("select 1 as foo where false")
>               list(curs)
E     RuntimeError: generator raised StopIteration

psycopg2cffi/tests/psycopg2_tests/test_bug_pep479_namedtuplecursor_iter.py:25: RuntimeError
```