### PR TITLE
Fix: psycopg2cffi.sql was not included in __init__.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.pyc
 *.egg-info
+.eggs
+.idea
 MANIFEST
 .tox/
 .cache

--- a/psycopg2cffi/__init__.py
+++ b/psycopg2cffi/__init__.py
@@ -2,6 +2,7 @@ import datetime
 from time import localtime
 
 from psycopg2cffi import extensions
+from psycopg2cffi import sql
 from psycopg2cffi import tz
 from psycopg2cffi._impl.adapters import Binary, Date, Time, Timestamp
 from psycopg2cffi._impl.adapters import DateFromTicks, TimeFromTicks


### PR DESCRIPTION
I could not do "from psycopg2cffi import sql" which was needed to run Odoo with this library. Including it in __init__.py fixes this.